### PR TITLE
Fix references to options in listeners

### DIFF
--- a/lib/map_views.js
+++ b/lib/map_views.js
@@ -55,12 +55,12 @@ module.exports.ItineraryMapView = Backbone.View.extend({
 
     this.listenTo(leg, 'fromclick', function() {
       var from = leg.get('from');
-      self.view.options.map.panTo([from.lat, from.lon]);
+      self.options.map.panTo([from.lat, from.lon]);
     });
 
     this.listenTo(leg, 'toclick', function() {
       var to = leg.get('to');
-      self.view.options.map.panTo([to.lat, to.lon]);
+      self.options.map.panTo([to.lat, to.lon]);
     });
 
     var steps = leg.get('steps');
@@ -74,11 +74,11 @@ module.exports.ItineraryMapView = Backbone.View.extend({
   initializeStep: function(step) {
     var self = this;
     this.listenTo(step, 'click', function() {
-      self.view.options.map.panTo([step.get('lat'), step.get('lon')]);
+      self.options.map.panTo([step.get('lat'), step.get('lon')]);
     });
 
     this.listenTo(step, 'mouseleave', function() {
-      self.view.options.map.closePopup();
+      self.options.map.closePopup();
     });
   },
 


### PR DESCRIPTION
Fix references to options.

This fix a couple of `Uncaught TypeError: Cannot read property 'options' of undefined` errors.