### PR TITLE
Adds route colors to narrative display for transit legs

### DIFF
--- a/lib/narrative-itinerary.html
+++ b/lib/narrative-itinerary.html
@@ -6,7 +6,7 @@
     </span>
     Option {{index}}:
     {{#each legs}}
-    <nobr>
+    <nobr {{#if attributes.routeColor }}style="background-color:#{{attributes.routeColor}};color:#{{attributes.routeTextColor}};"{{/if}}>
       <div class="otp-legMode-icon otp-legMode-icon-{{ attributes.mode }}"></div>
       {{#if attributes.routeShortName }}{{attributes.routeShortName}}{{/if}}
       {{#unless @last}}

--- a/lib/transit-leg.html
+++ b/lib/transit-leg.html
@@ -1,5 +1,5 @@
 <div class="otp-leg">
-  <div class="otp-legHeader">
+  <div class="otp-legHeader" {{#if routeColor }}style="background-color:#{{routeColor}};color:#{{routeTextColor}};"{{/if}}>
     <div class="agencyBranding" style="background-image: url({{agencyLogoUrl}});"></div>
     <span><b><a target="_blank" href="{{agencyUrl}}">{{agencyName}}</a></b></span>
     <b><div class="otp-legMode-icon otp-legMode-icon-{{ mode }}"></div> {{routeShortName}}</b> {{routeLongName}} to {{to.name}}


### PR DESCRIPTION
It changes background color of otp-Header leg and name of route.

It is shown only if transit legs have routeColor attribute. (It is assumed that
routeTextColor also exists)

It doesn't work nicely if routeColor is black. Because arrows and mode
icons are also black and are invisible if background is black.
Their color can't be changed with text color because they are images.

To fix this they would need to be icon font.

Fixes #40.