### PR TITLE
Nicer mobile UI with tabs

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,3 +1,25 @@
+//For bootstrap tabs
+var bs = require('components~bootstrap@3.3.4');
+
+//full: http://stackoverflow.com/questions/13029904/twitter-bootstrap-add-class-to-body-referring-to-its-mode
+//Assigns class to body based on the width of screen
+//This is used to move narrative from sidebar to own tab in small screens
+function assign_bootstrap_mode() {
+        var width = $( window ).width();
+        var mode = '';
+        var nar = $('#narrative').detach();
+        if (width<768) {
+                mode = 'mode-xs';
+                nar.appendTo('#plan');
+                /*console.log("Attached to plan");*/
+        }
+        else {
+                mode = 'mode-other';
+                nar.appendTo('#sidebar');
+                /*console.log("Attached to sidebar");*/
+        }
+        $('body').removeClass('mode-other').removeClass('mode-xs').addClass(mode);
+}
 
 $(document).ready(function() {
 
@@ -114,7 +136,14 @@ $(document).ready(function() {
     $('#map').height(height);
     $('#sidebar').height(height);
     map.invalidateSize();
+    assign_bootstrap_mode();
   };
+  $(document).on('shown.bs.tab', 'a.formap', function() {
+      map.invalidateSize();
+  });
   $(window).resize(resize);
   resize();
+  $('#tabs').tab();
+  map.invalidateSize();
+  assign_bootstrap_mode();
 });

--- a/component.json
+++ b/component.json
@@ -38,7 +38,8 @@
     "lib/narrative.css",
     "lib/map.css",
     "lib/request-form.css",
-    "lib/topo.css"
+    "lib/topo.css",
+    "lib/tabs.css"
   ],
   "images": [
     "lib/images"

--- a/index.html
+++ b/index.html
@@ -22,13 +22,22 @@
 	<body>
 		<div class="container">
 	    <div class="row">
-	      <div id="sidebar" class="col-sm-4 col-md-3">
-	        <div id="request"></div>
-	        <div id="narrative"></div>
-	      </div>
-	      <div class="col-sm-8 col-md-9 map-container">
-	        <div id="map"></div>
-	      </div>
+		<ul class="nav nav-tabs visible-xs" id="tabs" data-tabs="tabs">
+			<li class="active"><a href="#sidebar" data-toggle="tab">Input</a></li>
+			<li><a class="formap" href="#mymap" data-toggle="tab">Map</a></li>
+			<li><a href="#plan" data-toggle="tab">Plan</a></li>
+		</ul>
+		<div class="tab-content">
+			<div id="sidebar" class="col-sm-4 col-md-3 active tab-pane">
+				<div class="row" id="request"></div>
+				<div class="row" id="narrative"></div>
+			</div>
+			<div class="col-sm-8 col-md-9 tab-pane" id="mymap">
+				<div id="map" style="height: 700px"></div>
+			</div>
+			<div class="col-sm-4 col-md-3 tab-pane" id="plan">
+			</div>
+		</div>
 	    </div>
 		</div>
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 				<div class="row" id="request"></div>
 				<div class="row" id="narrative"></div>
 			</div>
-			<div class="col-sm-8 col-md-9 tab-pane" id="mymap">
+			<div class="col-sm-8 col-md-9 tab-pane map-container" id="mymap">
 				<div id="map" style="height: 700px"></div>
 			</div>
 			<div class="col-sm-4 col-md-3 tab-pane" id="plan">

--- a/lib/tabs.css
+++ b/lib/tabs.css
@@ -1,0 +1,4 @@
+/*always  shows tab pane when tabs aren't shown */
+body.mode-other .tab-pane {
+	display:block;
+} 


### PR DESCRIPTION
When width is < 768 three tabs are shown:
Input, Map and plan output
Instead of sidebar and a map

It uses bootstrap tabs and some Javascript to move narrative from sidebar to own tab.
It probably needs some changes since it looks weird now. Sidebar is a little cut on both sides.

Fixes #41