### PR TITLE
Add support for more geocoders (Nominatim, Pelias, Mapbox)

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -16,4 +16,5 @@ window.OTP_config = {
   // geocoder api endpoints
   nominatimApi: 'https://nominatim.openstreetmap.org/',
   esriApi: 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/',
+  peliasApi: 'https://pelias.mapzen.com/',
 }

--- a/client/config.js
+++ b/client/config.js
@@ -9,8 +9,8 @@ window.OTP_config = {
   otpApi: 'http://192.168.59.103:8080/otp/routers/',
 
   // geocoders to use:
-  geocoders: [ 'esri' ],
-  reverseGeocoder: 'esri', // possible choices: esri, nominatim
+  geocoders: [ 'mapbox' ], // possible choices: esri, otp, nominatim, pelias, mapbox
+  reverseGeocoder: 'esri', // possible choices: esri, nominatim, pelias, mapbox
   reverseGeocode: true,
 
   // geocoder api endpoints

--- a/client/config.js
+++ b/client/config.js
@@ -4,8 +4,16 @@ window.OTP_config = {
   osmMapKey: 'conveyal.ikck6888', // temporary -- do not use in production, provide your own
   aerialMapKey: 'conveyal.map-a3mk3jug', // unset
 
-  otpApi: 'http://192.168.59.103:8080/otp/routers/',
-  esriApi: 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/',
+  // mapboxAccessToken: 'Change this to your mapbox public token (starts with pk) if you want to use the mapbox geocoder',
 
-  reverseGeocode: true
+  otpApi: 'http://192.168.59.103:8080/otp/routers/',
+
+  // geocoders to use:
+  geocoders: [ 'esri' ],
+  reverseGeocoder: 'esri', // possible choices: esri, nominatim
+  reverseGeocode: true,
+
+  // geocoder api endpoints
+  nominatimApi: 'https://nominatim.openstreetmap.org/',
+  esriApi: 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/',
 }

--- a/client/config.js
+++ b/client/config.js
@@ -9,7 +9,7 @@ window.OTP_config = {
   otpApi: 'http://192.168.59.103:8080/otp/routers/',
 
   // geocoders to use:
-  geocoders: [ 'mapbox' ], // possible choices: esri, otp, nominatim, pelias, mapbox
+  geocoders: [ 'esri' ], // possible choices: esri, otp, nominatim, pelias, mapbox
   reverseGeocoder: 'esri', // possible choices: esri, nominatim, pelias, mapbox
   reverseGeocode: true,
 

--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -241,6 +241,14 @@ var geocoderLookup = {
 }
 
 var MultiGeocoder = {
+  reverse: function (place, callback) {
+    if (typeof window.OTP_config.reverseGeocoder === "undefined") {
+      EsriGeocoder.reverse(place, callback)
+    } else {
+      geocoderLookup[window.OTP_cnofig.reverseGeocoder].reverse(place, callback)
+    }
+  },
+
   suggest: function (query, callback, opts) {
     var queriesComplete = 0;
 
@@ -272,8 +280,7 @@ var MultiGeocoder = {
 
 module.exports = {
   EsriGeocoder: EsriGeocoder,
-  OtpBuiltInGeocoder: OtpBuiltInGeocoder,
   lookup: EsriGeocoder.lookup,
-  reverse: EsriGeocoder.reverse,
+  reverse: MultiGeocoder.reverse,
   suggest: MultiGeocoder.suggest
 }

--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -342,6 +342,92 @@ var PeliasGeocoder = {
     }
   }
 }
+
+/* Mapbox's geocoder */
+
+var MapboxGeocoder = {
+  reverse: function (place, callback) {
+    var latlon = place.split(',')
+
+    if (typeof window.OTP_config.mapboxAccessToken === "undefined") {
+      console.log("WARNING: You haven't set a mapbox access token!")
+      return callback()
+    }
+
+    var params = {
+      access_token: window.OTP_config.mapboxAccessToken,
+    }
+
+    $.ajax({
+      url: '//api.mapbox.com/v4/geocode/mapbox.places/' + encodeURIComponent(query) + '.json',
+      type: 'GET',
+      data: params,
+      dataType: 'json',
+      error: callback,
+      success: function (res) {
+        if (res.features.length <= 0) {
+          return callback('No address found for ' + latlon[1] + ',' + latlon[0], {
+            text: 'No address found for location',
+            place: place
+          })
+        }
+        var lonlat = res.features[0].geometry.coordinates
+        callback(null, {
+          address: res.features[0].place_name,
+          // city: address.city,
+          // state: address.state,
+          place: lonlat[1] + ',' + lonlat[0]
+        })
+      }
+    })
+  },
+
+  lookup: function (query, callback) {
+    if (!query.length) return callback()
+
+    if (typeof window.OTP_config.mapboxAccessToken === "undefined") {
+      console.log("WARNING: You haven't set a mapbox access token!")
+      return callback()
+    }
+
+    var params = {
+      access_token: window.OTP_config.mapboxAccessToken,
+    }
+
+    /* Mapbox also takes in lon/lat */
+    if(initialLocation) params.proximity = initialLocation
+
+    $.ajax({
+      url: '//api.mapbox.com/v4/geocode/mapbox.places/' + encodeURIComponent(query) + '.json',
+      type: 'GET',
+      data: params,
+      dataType: 'json',
+      error: callback,
+      success: function (res) {
+        var data = []
+        for (var itemPos in res.features.slice(0, maxSuggestResults)) {
+          var resultItem = res.features[itemPos]
+          var lonlat = resultItem.geometry.coordinates
+          var item = {
+            id: parseInt(itemPos) + 1,
+            text: resultItem.place_name,
+            place: lonlat[1] + ',' + lonlat[0],
+            source: 'mapbox'
+          }
+
+          data.push(item)
+        }
+
+        callback(data)
+      }
+    })
+  },
+
+  suggest: function (query, callback) {
+    MapboxGeocoder.lookup(query, callback)
+  }
+}
+
 /* Geocoding function that splits suggest query between multiple other geocoders */
 
 // Array of geocoder ids to lookup. Defaults to 'esri' only, can be overriddin in config
@@ -353,6 +439,7 @@ var geocoderLookup = {
   otp : OtpBuiltInGeocoder,
   nominatim : NominatimGeocoder,
   pelias : PeliasGeocoder,
+  mapbox : MapboxGeocoder,
 }
 
 var MultiGeocoder = {
@@ -360,7 +447,7 @@ var MultiGeocoder = {
     if (typeof window.OTP_config.reverseGeocoder === "undefined") {
       EsriGeocoder.reverse(place, callback)
     } else {
-      geocoderLookup[window.OTP_cnofig.reverseGeocoder].reverse(place, callback)
+      geocoderLookup[window.OTP_config.reverseGeocoder].reverse(place, callback)
     }
   },
 

--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -228,6 +228,120 @@ var NominatimGeocoder = {
   }
 }
 
+/* Mapzen's pelias geocoder */
+
+var PeliasGeocoder = {
+  reverse: function (place, callback) {
+    var latlon = place.split(',')
+
+    var params = {
+      lat: latlon[0],
+      lon: latlon[1],
+    }
+
+    $.ajax({
+      url: window.OTP_config.peliasApi + '/reverse',
+      type: 'GET',
+      data: params,
+      dataType: 'json',
+      error: callback,
+      success: function (res) {
+        if (res.features.length <= 0) {
+          return callback('No address found for ' + latlon[1] + ',' + latlon[0], {
+            text: 'No address found for location',
+            place: place
+          })
+        }
+        var lonlat = res.features[0].geometry.coordinates
+        callback(null, {
+          address: res.features[0].properties.text,
+          // city: address.city,
+          // state: address.state,
+          place: lonlat[1] + ',' + lonlat[0]
+        })
+      }
+    })
+  },
+
+  lookup: function (query, callback) {
+    if (!query.length) return callback()
+
+    var params = {
+      input: query,
+      size: maxSuggestResults,
+    }
+
+    if(window.OTP_config.initLatLng && window.OTP_config.initLatLng.length === 2) {
+      params.lat = window.OTP_config.initLatLng[0]
+      params.lon = window.OTP_config.initLatLng[1]
+    }
+
+    $.ajax({
+      url: window.OTP_config.peliasApi + '/search',
+      type: 'GET',
+      data: params,
+      dataType: 'json',
+      error: callback,
+      success: function (res) {
+        var data = []
+        for (var itemPos in res.features.slice(0, maxSuggestResults)) {
+          var resultItem = res.features[itemPos]
+          var lonlat = resultItem.geometry.coordinates
+          var item = {
+            id: parseInt(itemPos) + 1,
+            text: resultItem.properties.text,
+            place: lonlat[1] + ',' + lonlat[0],
+            source: 'pelias'
+          }
+
+          data.push(item)
+        }
+
+        callback(data)
+      }
+    })
+  },
+
+  suggest: function (query, callback) {
+    if (!query.length) return callback()
+
+    if(window.OTP_config.initLatLng && window.OTP_config.initLatLng.length === 2) {
+        var params = {
+          input: query,
+          size: maxSuggestResults,
+          lat: window.OTP_config.initLatLng[0],
+          lon: window.OTP_config.initLatLng[1]
+        }
+
+      $.ajax({
+        url: window.OTP_config.peliasApi + '/suggest',
+        type: 'GET',
+        data: params,
+        dataType: 'json',
+        error: callback,
+        success: function (res) {
+          var data = []
+          for (var itemPos in res.features.slice(0, maxSuggestResults)) {
+            var resultItem = res.features[itemPos]
+            var lonlat = resultItem.geometry.coordinates
+            var item = {
+              id: parseInt(itemPos) + 1,
+              text: resultItem.properties.text,
+              place: lonlat[1] + ',' + lonlat[0],
+              source: 'pelias'
+            }
+
+            data.push(item)
+          }
+
+          callback(data)
+        }
+      })
+    } else {
+      PeliasGeocoder.lookup(query, callback)
+    }
+  }
+}
 /* Geocoding function that splits suggest query between multiple other geocoders */
 
 // Array of geocoder ids to lookup. Defaults to 'esri' only, can be overriddin in config
@@ -237,7 +351,8 @@ var geocoders = window.OTP_config.geocoders || ['esri']
 var geocoderLookup = {
   esri : EsriGeocoder,
   otp : OtpBuiltInGeocoder,
-  nominatim : NominatimGeocoder
+  nominatim : NominatimGeocoder,
+  pelias : PeliasGeocoder,
 }
 
 var MultiGeocoder = {

--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -152,6 +152,82 @@ var OtpBuiltInGeocoder = {
   }
 }
 
+/* OSM's nominatim geocoder */
+
+var NominatimGeocoder = {
+  reverse: function (place, callback) {
+    var latlon = place.split(',')
+
+    $.ajax({
+      url: window.OTP_config.nominatimApi + 'reverse',
+      data: {
+        lat: latlon[0],
+        lon: latlon[1],
+        format: 'json'
+      },
+      type: 'GET',
+      dataType: 'jsonp',
+      jsonp: 'json_callback',
+      error: callback,
+      success: function (res) {
+        if (!res.address.road) {
+          return callback('No address found for ' + latlon[1] + ',' + latlon[0], {
+            text: 'No address found for location',
+            place: place
+          })
+        }
+
+        var address = res.address
+        var location = res.location
+        callback(null, {
+          address: address.road,
+          city: address.city,
+          state: address.state,
+          place: res.lon + ',' + res.lat
+        })
+      }
+    })
+  },
+
+  lookup: function (query, callback) {
+    if (!query.length) return callback()
+
+    var params = {
+      countrycodes: 'us',
+      format: 'json',
+      q: query,
+    }
+
+    $.ajax({
+      url: window.OTP_config.nominatimApi + 'search',
+      type: 'GET',
+      data: params,
+      dataType: 'jsonp',
+      jsonp: 'json_callback',
+      error: callback,
+      success: function (res) {
+        var data = []
+        for (var itemPos in res.slice(0, maxSuggestResults)) {
+          var item = {
+            id: itemPos + 1,
+            text: res[itemPos].display_name,
+            place: res[itemPos].lat + ',' + res[itemPos].lon,
+            source: 'nominatim'
+          }
+
+          data.push(item)
+        }
+
+        callback(data)
+      }
+    })
+  },
+
+  suggest: function (query, callback) {
+    NominatimGeocoder.lookup(query, callback)
+  }
+}
+
 /* Geocoding function that splits suggest query between multiple other geocoders */
 
 // Array of geocoder ids to lookup. Defaults to 'esri' only, can be overriddin in config
@@ -160,7 +236,8 @@ var geocoders = window.OTP_config.geocoders || ['esri']
 // Lookup mapping geocoder id to object
 var geocoderLookup = {
   esri : EsriGeocoder,
-  otp : OtpBuiltInGeocoder
+  otp : OtpBuiltInGeocoder,
+  nominatim : NominatimGeocoder
 }
 
 var MultiGeocoder = {


### PR DESCRIPTION
This pull request adds in support for other geocoding services besides ESRI.

Which geocoder to use for reverse geocoding can also be configured in config.js. For normal geocoding, multiple geocoders' results are combined, the same way it was done with the built-in OTP geocoder.

One note: this code doesn't set the city and state properties of the returned object when reverse geocoding. Searching the source tree, it seems no code relies on it (and in fact, it seems to work fine). Not all geocoders return the address in a structured format, so finding this information would be difficult for some geocoders.