### PR TITLE
Adds optional searchExtent support to the geocoder

### DIFF
--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -7,6 +7,12 @@ if (window.OTP_config.initLatLng && window.OTP_config.initLatLng.length === 2) {
   var esriLocation = window.OTP_config.initLatLng[1] + ',' + window.OTP_config.initLatLng[0]
 }
 
+// Utilize a searchExtent bounding box in the format expected by the ESRI
+// geocoder, if avaiable.
+if (window.OTP_config.searchExtent) {
+  var searchExtent = window.OTP_config.searchExtent;
+}
+
 var EsriGeocoder = {
   reverse: function (place, callback) {
     // esri takes lon/lat
@@ -85,6 +91,8 @@ var EsriGeocoder = {
       text: query
     }
     if (esriLocation) params.location = esriLocation
+
+    if (searchExtent) params.searchExtent = searchExtent
 
     $.ajax({
       url: window.OTP_config.esriApi + 'suggest',


### PR DESCRIPTION
This pull request addresses #75 

Provides the ability to set a window.OTP_config.searchExtent in the format expected by the arcgis geocoder: https://developers.arcgis.com/rest/geocode/api-reference/geocoding-suggest.htm.

I kept in generically named though, since it could be valuable for the other geocoders.