### PR TITLE
Feature/mobile interaction improvements

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -53,11 +53,6 @@ $(document).ready(function () {
   // display the OSM street layer by default
   osmLayer.addTo(map)
 
-  // disable map drag on mobile
-  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
-    map.dragging.disable()
-  }
-
   // create a data model for the currently visible stops, and point it
   // to the corresponding API method
   var stopsRequestModel = new OTP.StopsInRectangleRequest()

--- a/lib/request-map-view.js
+++ b/lib/request-map-view.js
@@ -24,29 +24,27 @@ var RequestMapView = Backbone.View.extend({
     this.options.map.on('contextmenu', _.bind(function (evt) {
       var mouseEvent = evt.originalEvent
       mouseEvent.preventDefault()
-      if (mouseEvent.which === 3) {
-        if (!this.contextMenu) {
-          this.contextMenu = $(mapContextMenuTemplate()).appendTo('body')
-        }
-
-        this.contextMenu.find('.setStartLocation').click(_.bind(function () {
-          this.model.set({
-            fromPlace: evt.latlng.lat + ',' + evt.latlng.lng
-          })
-        }, this))
-
-        this.contextMenu.find('.setEndLocation').click(_.bind(function () {
-          this.model.set({
-            toPlace: evt.latlng.lat + ',' + evt.latlng.lng
-          })
-        }, this))
-
-        this.contextMenu.show()
-          .css({
-            top: mouseEvent.pageY + 'px',
-            left: mouseEvent.pageX + 'px'
-          })
+      if (!this.contextMenu) {
+        this.contextMenu = $(mapContextMenuTemplate()).appendTo('body')
       }
+
+      this.contextMenu.find('.setStartLocation').click(_.bind(function () {
+        this.model.set({
+          fromPlace: evt.latlng.lat + ',' + evt.latlng.lng
+        })
+      }, this))
+
+      this.contextMenu.find('.setEndLocation').click(_.bind(function () {
+        this.model.set({
+          toPlace: evt.latlng.lat + ',' + evt.latlng.lng
+        })
+      }, this))
+
+      this.contextMenu.show()
+        .css({
+          top: mouseEvent.pageY + 'px',
+          left: mouseEvent.pageX + 'px'
+        })
       return false
     }, this))
 


### PR DESCRIPTION
Our organization would like to provide the following pull request, which brings some feature parity between mobile and desktop.

First, dragging is no longer disabled for mobile userAgents. This way users can better interact with the map for adding start or end points.

Second, when responding to a "contextmenu" event, the code no longer checks to see which mouse button is pressed. I don't believe this check is necessary since the contextmenu event will only fire for right click or long press [according to the leaflet documentation](http://leafletjs.com/reference.html#map-contextmenu).

the [.which property](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which) appears to be non-standard anyways. 

This check was preventing mobile users from doing a long press event on the map, to get the context menu.