### PR TITLE
Fix wheelchair option and parse query params on `start` route

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -114,6 +114,8 @@ $(document).ready(function () {
     },
     start: function (lat, lon, zoom, querystring) {
       map.setView(L.latLng(lat, lon), zoom)
+
+      // if query string is specified in the start route, toggle the form settings on
       if (querystring) {
         requestModel.fromQueryString(querystring)
         requestView.toggleSettings()

--- a/client/client.js
+++ b/client/client.js
@@ -108,16 +108,21 @@ $(document).ready(function () {
 
   var Router = Backbone.Router.extend({
     routes: {
-      'start/:lat/:lon/:zoom': 'start',
+      'start/:lat/:lon/:zoom(?*querystring)': 'start',
       'start/:lat/:lon/:zoom/:routerId': 'startWithRouterId',
       'plan(?*querystring)': 'plan'
     },
-    start: function (lat, lon, zoom) {
+    start: function (lat, lon, zoom, querystring) {
       map.setView(L.latLng(lat, lon), zoom)
+      if (querystring) {
+        requestModel.fromQueryString(querystring)
+        requestView.toggleSettings()
+      }
     },
     startWithRouterId: function (lat, lon, zoom, routerId) {
       window.OTP_config.routerId = routerId
 
+      stopsRequestModel.urlRoot = window.OTP_config.otpApi + routerId + '/index/stops'
       requestModel.urlRoot = window.OTP_config.otpApi + routerId + '/plan'
       map.setView(L.latLng(lat, lon), zoom)
     },

--- a/client/client.js
+++ b/client/client.js
@@ -33,18 +33,18 @@ $(document).ready(function () {
 
   // create OpenStreetMap tile layers for streets and aerial imagery
   var osmLayer = L.tileLayer('//{s}.tiles.mapbox.com/v3/' + window.OTP_config
-      .osmMapKey + '/{z}/{x}/{y}{scale}.png', {
+    .osmMapKey + '/{z}/{x}/{y}{scale}.png', {
       subdomains: ['a', 'b', 'c', 'd'],
       attribution: 'Street Map <a href="//mapbox.com/about/maps">Terms & Feedback</a>',
       scale: L.Browser.retina ? '@2x' : '',
-			detectRetina: true
+      detectRetina: true
     })
   var aerialLayer = L.tileLayer('//{s}.tiles.mapbox.com/v3/' + window.OTP_config
-      .aerialMapKey + '/{z}/{x}/{y}{scale}.png', {
+    .aerialMapKey + '/{z}/{x}/{y}{scale}.png', {
       subdomains: ['a', 'b', 'c', 'd'],
       attribution: 'Satellite Map <a href="//mapbox.com/about/maps">Terms & Feedback</a>',
       scale: L.Browser.retina ? '@2x' : '',
-			detectRetina: true
+      detectRetina: true
     })
 
   // create a leaflet layer control and add it to the map

--- a/lib/plan-request.js
+++ b/lib/plan-request.js
@@ -31,7 +31,7 @@ var PlanRequest = Backbone.Model.extend({
     time: null,
     routerId: null,
     arriveBy: null,
-    wheelchair: null,
+    wheelchair: false,
     maxWalkDistance: 8046,
     walkSpeed: null,
     bikeSpeed: null,
@@ -51,8 +51,7 @@ var PlanRequest = Backbone.Model.extend({
     bannedTrips: null,
     transferPenalty: null,
     maxTransfers: null,
-    numItineraries: 3,
-    wheelchairAccessible: false
+    numItineraries: 3
   },
 
   request: function () {

--- a/lib/request-form.js
+++ b/lib/request-form.js
@@ -120,7 +120,7 @@ var RequestView = Backbone.View.extend({
       }
 
       if (data.attributes.wheelchair) {
-        view.$('#wheelchairAccessible').prop('checked', true)
+        view.$('#wheelchair').prop('checked', true)
       }
 
       view.updateModeControls()
@@ -255,7 +255,7 @@ var RequestView = Backbone.View.extend({
       maxWalkDistance: maxDistance,
       optimize: this.$('#optimize').val(),
       mode: this.$('#mode').val(),
-      wheelchair: this.$('#wheelchairAccessible').prop('checked')
+      wheelchair: this.$('#wheelchair').prop('checked')
     }
 
     // skip if either to/from fields are unset

--- a/lib/request-form.js
+++ b/lib/request-form.js
@@ -119,7 +119,7 @@ var RequestView = Backbone.View.extend({
         view.timepicker.setDate(time)
       }
 
-      if (data.attributes.wheelchairAccessible) {
+      if (data.attributes.wheelchair) {
         view.$('#wheelchairAccessible').prop('checked', true)
       }
 
@@ -255,7 +255,7 @@ var RequestView = Backbone.View.extend({
       maxWalkDistance: maxDistance,
       optimize: this.$('#optimize').val(),
       mode: this.$('#mode').val(),
-      wheelchairAccessible: this.$('#wheelchairAccessible').prop('checked')
+      wheelchair: this.$('#wheelchairAccessible').prop('checked')
     }
 
     // skip if either to/from fields are unset

--- a/lib/templates/request-form.html
+++ b/lib/templates/request-form.html
@@ -80,7 +80,7 @@
       <div class="col-sm-offset-4 col-sm-8">
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="wheelchairAccessible" id="wheelchairAccessible"> Wheelchair Accessible
+            <input type="checkbox" name="wheelchair" id="wheelchair"> Wheelchair Accessible
           </label>
         </div>
       </div>


### PR DESCRIPTION
Previously otp.js used the `wheelchairAccessible` query param and not the correct `wheelchair` param.

Also, there was previously no way to specify trip query parameters in the `start` route (i.e., start at a given location with the form pre-populated).  This fixes that also.