### PR TITLE
Fix wheelchair accessibility and replace deprecated TRAINISH mode option

### DIFF
--- a/client/config.js.template
+++ b/client/config.js.template
@@ -23,8 +23,8 @@ window.OTP_config = {
   mapzenApi: 'https://search.mapzen.com/v1/',
 
   // specify modes to be enabled in 'travel by' dropdown as list of OTP modes
-  // defaults to: 'TRANSIT,WALK', 'TRAINISH,WALK', 'BUS,WALK', 'WALK', 'BICYCLE', 'TRANSIT,BICYCLE'
+  // defaults to: 'TRANSIT,WALK', 'SUBWAY,WALK', 'BUS,WALK', 'WALK', 'BICYCLE', 'TRANSIT,BICYCLE'
   //
   // e.g. uncomment following line to add drive-to-transit to the default list
-  modes: [ 'TRANSIT,WALK', 'TRAINISH,WALK', 'BUS,WALK', 'WALK', 'BICYCLE', 'TRANSIT,BICYCLE', 'TRANSIT,CAR_PARK' ]
+  modes: [ 'TRANSIT,WALK', 'SUBWAY,WALK', 'BUS,WALK', 'WALK', 'BICYCLE', 'TRANSIT,BICYCLE', 'TRANSIT,CAR_PARK' ]
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -33,12 +33,16 @@ Handlebars.registerHelper('ordinal', function (n) {
 })
 
 Handlebars.registerHelper('modeString', function (mode) {
-  switch(mode) {
+  switch (mode) {
     case 'TRANSIT':
     case 'TRANSIT,WALK':
       return 'Transit'
-    case 'TRAINISH':
-    case 'TRAINISH,WALK':
+    case 'SUBWAY':
+    case 'SUBWAY,WALK':
+    case 'SUBWAY,TRAM':
+    case 'SUBWAY,TRAM,WALK':
+    case 'SUBWAY,TRAM,RAIL':
+    case 'SUBWAY,TRAM,RAIL,WALK':
       return 'Train only'
     case 'BUS':
     case 'BUS,WALK':

--- a/lib/itinerary-leg.js
+++ b/lib/itinerary-leg.js
@@ -52,8 +52,7 @@ var ItineraryLeg = Backbone.Model.extend({
   isTransit: function (mode) {
     mode = mode || this.get('mode')
     return mode === 'TRANSIT' || mode === 'SUBWAY' || mode === 'FERRY' || mode === 'RAIL' ||
-    mode === 'BUS' || mode === 'TRAM' || mode === 'GONDOLA' || mode ===
-    'TRAINISH' || mode === 'BUSISH'
+    mode === 'BUS' || mode === 'TRAM' || mode === 'GONDOLA' || mode === 'BUSISH'
   },
 
   isWalk: function (mode) {

--- a/lib/request-form.js
+++ b/lib/request-form.js
@@ -12,7 +12,7 @@ var _ = window._
 
 var requestFormTemplate = Handlebars.compile(require('./templates/request-form.html'))
 
-var defaultModes = [ 'TRANSIT,WALK', 'TRAINISH,WALK', 'BUS,WALK', 'WALK', 'BICYCLE', 'TRANSIT,BICYCLE' ]
+var defaultModes = [ 'TRANSIT,WALK', 'SUBWAY,TRAM,RAIL,WALK', 'BUS,WALK', 'WALK', 'BICYCLE', 'TRANSIT,BICYCLE' ]
 
 var RequestView = Backbone.View.extend({
   events: {

--- a/lib/request-form.js
+++ b/lib/request-form.js
@@ -119,7 +119,7 @@ var RequestView = Backbone.View.extend({
         view.timepicker.setDate(time)
       }
 
-      if (data.attributes.wheelchair) {
+      if (data.attributes.wheelchair === 'true') {
         view.$('#wheelchair').prop('checked', true)
       }
 


### PR DESCRIPTION
In OTP v1.0 and later, the `TRAINISH` mode has been removed.  This PR replaces that mode with `SUBWAY,TRAM,TRAIN` in the default modes and config.  It also fixes a bug where the `wheelchair_accessible` option was not correctly checking the value of that parameter, which resulted in any form change also defaulting the wheelchair value to `true`.