### PR TITLE
Upgrade Mapbox to use v4 URL path and tokens

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -32,16 +32,21 @@ $(document).ready(function () {
   map.attributionControl.setPrefix('')
 
   // create OpenStreetMap tile layers for streets and aerial imagery
-  var osmLayer = L.tileLayer('//{s}.tiles.mapbox.com/v3/' + window.OTP_config
-    .osmMapKey + '/{z}/{x}/{y}{scale}.png', {
-      subdomains: ['a', 'b', 'c', 'd'],
+  var osmLayer = L.tileLayer('https://api.tiles.mapbox.com/v4/' +
+      window.OTP_config.osmMapKey +
+      '/{z}/{x}/{y}{scale}.png?access_token=' +
+      window.OTP_config.mapToken,
+    {
       attribution: 'Street Map <a href="//mapbox.com/about/maps">Terms & Feedback</a>',
       scale: L.Browser.retina ? '@2x' : '',
       detectRetina: true
-    })
-  var aerialLayer = L.tileLayer('//{s}.tiles.mapbox.com/v3/' + window.OTP_config
-    .aerialMapKey + '/{z}/{x}/{y}{scale}.png', {
-      subdomains: ['a', 'b', 'c', 'd'],
+    }
+  )
+  var aerialLayer = L.tileLayer('https://api.tiles.mapbox.com/v4/' +
+      window.OTP_config.aerialMapKey +
+      '/{z}/{x}/{y}{scale}.png?access_token=' +
+      window.OTP_config.mapToken,
+    {
       attribution: 'Satellite Map <a href="//mapbox.com/about/maps">Terms & Feedback</a>',
       scale: L.Browser.retina ? '@2x' : '',
       detectRetina: true

--- a/client/client.js
+++ b/client/client.js
@@ -39,6 +39,9 @@ $(document).ready(function () {
     {
       attribution: 'Street Map <a href="//mapbox.com/about/maps">Terms & Feedback</a>',
       scale: L.Browser.retina ? '@2x' : '',
+      // Zoom offset and tile size adjust for retina-sized tiles.
+      zoomOffset: -1,
+      tileSize: L.Browser.retina ? 512 : 256,
       detectRetina: true
     }
   )
@@ -49,6 +52,9 @@ $(document).ready(function () {
     {
       attribution: 'Satellite Map <a href="//mapbox.com/about/maps">Terms & Feedback</a>',
       scale: L.Browser.retina ? '@2x' : '',
+      // Zoom offset and tile size adjust for retina-sized tiles.
+      zoomOffset: -1,
+      tileSize: L.Browser.retina ? 512 : 256,
       detectRetina: true
     })
 

--- a/client/config.js.template
+++ b/client/config.js.template
@@ -2,7 +2,8 @@ window.OTP_config = {
   initLatLng: [45.52, -122.681944],
 
   osmMapKey: 'your-mapbox-osm-key',
-  aerialMapKey: 'your-mapbox-aerial-key'
+  aerialMapKey: 'your-mapbox-aerial-key',
+  mapToken: 'your-mapbox-access-token',
 
   // mapzenApiKey: "your-key", // your Mapzen Search API key
   // geocoderSearchRadius : 25, // search radius in km for mapzen geocoder from initLatLng (defaults to 50 if not specified)


### PR DESCRIPTION
This updates the map layers to use v4 style Mapbox URLs and adds the `mapToken` config variable.